### PR TITLE
Fix deployment workflow and E2E test configuration

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -111,16 +111,16 @@ jobs:
         TEST_TYPE="${{ github.event.inputs.test_type || 'smoke' }}"
         case "$TEST_TYPE" in
           "smoke")
-            npm run test:e2e:smoke
+            npm run test:smoke
             ;;
           "regression")
-            npm run test:e2e:regression
+            npm run test
             ;;
           "all")
-            npm run test:e2e
+            npm run test
             ;;
           *)
-            npm run test:e2e:smoke
+            npm run test:smoke
             ;;
         esac
       env:
@@ -132,8 +132,7 @@ jobs:
     - name: Generate test report
       if: always()
       run: |
-        cd e2e
-        npm run test:e2e:report || true
+        echo "Test report generation skipped (no report script configured)"
 
     - name: Upload test results
       uses: actions/upload-artifact@v4
@@ -191,7 +190,7 @@ jobs:
     - name: Run parallel E2E tests
       run: |
         cd e2e
-        npm run test:e2e:parallel
+        npm run test
       env:
         HEADLESS: 'true'
         APP_URL: 'http://localhost:8000'


### PR DESCRIPTION
  ## Summary

  Comprehensive fixes for deployment workflow and E2E test configuration issues.

  ## Problems Fixed

  1. **Deployment Workflow Error**: "Branch develop is not allowed to deploy to github-pages"
  2. **GitHub Actions Cache Error**: "Dependencies lock file is not found"
  3. **E2E Test Script Error**: "Missing script: test:e2e:smoke"

  ## Changes

  ### Deployment Workflow
  - Changed trigger from `pull_request` to `push` on main branch
  - Updated deployment summary to use commit SHA

  ### Package Lock Files
  - Removed `package-lock.json` from .gitignore
  - Added root `package-lock.json`
  - Added `e2e/package-lock.json`

  ### E2E Test Scripts
  - Fixed script names to match e2e/package.json:
    - `test:e2e:smoke` → `test:smoke`
    - `test:e2e:regression` → `test`
    - `test:e2e:parallel` → `test`
  - Removed non-existent `test:e2e:report` call

  ### Documentation
  - Updated README.md deployment configuration
  - Updated README_jp.md deployment configuration

  ## Benefits

  - ✅ GitHub Pages deployment now works
  - ✅ E2E Tests workflow executes successfully
  - ✅ Consistent dependencies across environments
  - ✅ Faster CI/CD with npm cache

  🤖 Generated with [Claude Code](https://claude.com/claude-code)