### PR TITLE
Fix Performance Tests port conflict in scheduled runs

### DIFF
--- a/lighthouse.config.js
+++ b/lighthouse.config.js
@@ -2,9 +2,6 @@ module.exports = {
   ci: {
     collect: {
       url: ['http://localhost:8000'],
-      startServerCommand: 'npm run serve',
-      startServerReadyPattern: 'Serving HTTP',
-      startServerReadyTimeout: 30000,
       numberOfRuns: 3,
       settings: {
         chromeFlags: '--no-sandbox --disable-dev-shm-usage',


### PR DESCRIPTION
## 概要
スケジュール実行で毎日失敗していたPerformance Testsのポート競合問題を修正しました。

## 問題
- スケジュール実行（毎日午前2時UTC）でPerformance Testsが連続失敗
- エラー: `OSError: [Errno 98] Address already in use`
- 失敗期間: 2025年11月8日以降

## 根本原因
ポート8000の二重起動:
1. ワークフローが `npm run serve &` でサーバーを起動
2. Lighthouse CIも `startServerCommand: 'npm run serve'` でサーバーを起動
3. 両方がポート8000を使おうとして競合

## 修正内容
`lighthouse.config.js` から以下を削除:
- `startServerCommand: 'npm run serve'`
- `startServerReadyPattern: 'Serving HTTP'`
- `startServerReadyTimeout: 30000`

ワークフローで起動済みのサーバーをLighthouse CIが使用するように変更。

## 変更の影響
- ✅ スケジュール実行のPerformance Testsが成功するようになる
- ✅ push/pull_requestトリガーには影響なし
- ✅ Lighthouse CIの機能には変更なし（既存サーバーを使用）

## テスト
- [x] 修正内容を確認
- [ ] PR作成後、次回のスケジュール実行（明日午前2時UTC）で検証

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)