### PR TITLE
Add user profile page with user info, memo, and purchase history

### DIFF
--- a/e2e/features/todo.feature
+++ b/e2e/features/todo.feature
@@ -7,6 +7,7 @@ Feature: Todo List Management
     Given the application is available
     And the user is logged in as "demo"
     And the language is set to English
+    And the user is on the profile page
     And the todo list is empty
 
   @smoke @todo

--- a/e2e/step-definitions/todo.steps.ts
+++ b/e2e/step-definitions/todo.steps.ts
@@ -3,6 +3,13 @@ import { expect } from '@playwright/test';
 import { CustomWorld } from '../support/world';
 
 // Given Steps
+Given('the user is on the profile page', async function(this: CustomWorld) {
+  // Navigate to user profile page
+  await this.page.goto(this.config.appUrl + '/user-profile.html');
+  await this.page.waitForLoadState('networkidle');
+  await this.page.waitForTimeout(500);
+});
+
 Given('the todo list is empty', async function(this: CustomWorld) {
   // Clear all todos by clicking the delete button (second .todo-btn in each item)
   // Skip items that are just "empty" placeholder

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
                     <button id="lang-ja" class="lang-btn active" data-lang="ja">JP</button>
                 </div>
                 <div id="user-info" class="user-info" style="display: none;">
-                    <span id="username"></span>
+                    <a href="user-profile.html" id="username" class="user-link"></a>
                     <button id="logout-btn" class="btn btn-secondary" data-i18n="logout">ログアウト</button>
                 </div>
                 <button id="login-btn" class="btn btn-primary" data-i18n="login">ログイン</button>
@@ -224,17 +224,6 @@
                         <button id="view-history-btn" class="btn btn-secondary" data-i18n="view_order_history">注文履歴を見る</button>
                     </section>
 
-                    <!-- ToDoリスト -->
-                    <section class="todo-section">
-                        <h3 data-i18n="favorite_memo">お気に入り商品メモ</h3>
-                        <div class="todo-input-group">
-                            <input type="text" id="todo-input" placeholder="メモを追加..." class="todo-input" data-i18n-placeholder="memo_placeholder">
-                            <button id="add-todo-btn" class="btn btn-primary" data-i18n="add">追加</button>
-                        </div>
-                        <ul id="todo-list" class="todo-list">
-                            <!-- ToDoアイテムが動的に表示される -->
-                        </ul>
-                    </section>
                 </aside>
             </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -60,6 +60,20 @@ body {
     gap: 1rem;
 }
 
+.user-link {
+    color: white;
+    text-decoration: none;
+    font-weight: 500;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    transition: all 0.3s ease;
+}
+
+.user-link:hover {
+    background: rgba(255, 255, 255, 0.2);
+    text-decoration: underline;
+}
+
 /* 言語切り替え */
 .language-switcher {
     display: flex;

--- a/user-profile.html
+++ b/user-profile.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title data-i18n="user_profile">ユーザー情報 - ShopTodo</title>
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="styles.css">
+    <style>
+        .profile-container {
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        .profile-section {
+            background: rgba(255, 255, 255, 0.9);
+            backdrop-filter: blur(10px);
+            padding: 2rem;
+            border-radius: 20px;
+            box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.2);
+            border: 1px solid rgba(255, 255, 255, 0.18);
+            margin-bottom: 2rem;
+        }
+
+        .profile-section h2 {
+            font-family: 'Poppins', sans-serif;
+            margin-bottom: 1.5rem;
+            color: #2d3748;
+            font-weight: 600;
+            font-size: 1.5rem;
+            border-bottom: 3px solid;
+            border-image: linear-gradient(135deg, #00a5bf 0%, #008c9e 100%) 1;
+            padding-bottom: 0.75rem;
+        }
+
+        .profile-form .form-group {
+            margin-bottom: 1.5rem;
+        }
+
+        .profile-form label {
+            display: block;
+            margin-bottom: 0.5rem;
+            font-weight: 600;
+            color: #2d3748;
+        }
+
+        .profile-form input,
+        .profile-form select {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            font-size: 1rem;
+            transition: all 0.3s ease;
+        }
+
+        .profile-form input:focus,
+        .profile-form select:focus {
+            outline: none;
+            border-color: #00a5bf;
+            box-shadow: 0 0 0 3px rgba(0, 165, 191, 0.1);
+        }
+
+        .profile-actions {
+            display: flex;
+            gap: 1rem;
+            margin-top: 1.5rem;
+        }
+
+        .back-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            color: white;
+            text-decoration: none;
+            margin-bottom: 1.5rem;
+            font-weight: 500;
+            transition: all 0.3s ease;
+        }
+
+        .back-link:hover {
+            text-decoration: underline;
+        }
+
+        .page-title {
+            color: white;
+            font-family: 'Poppins', sans-serif;
+            font-size: 2rem;
+            margin-bottom: 2rem;
+            text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+        }
+
+        /* Todo Section */
+        .todo-input-group {
+            display: flex;
+            gap: 0.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .todo-input {
+            flex: 1;
+            padding: 0.75rem 1rem;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            font-size: 1rem;
+        }
+
+        .todo-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .todo-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0.75rem 0;
+            border-bottom: 1px solid #eee;
+        }
+
+        .todo-item:last-child {
+            border-bottom: none;
+        }
+
+        .todo-text {
+            flex: 1;
+            font-size: 1rem;
+        }
+
+        .todo-text.completed {
+            text-decoration: line-through;
+            color: #666;
+        }
+
+        .todo-controls {
+            display: flex;
+            gap: 0.25rem;
+        }
+
+        .todo-btn {
+            background: none;
+            border: none;
+            cursor: pointer;
+            padding: 0.5rem;
+            border-radius: 4px;
+            font-size: 1rem;
+        }
+
+        .todo-btn:hover {
+            background: #e9ecef;
+        }
+
+        /* Order History */
+        .order-history-item {
+            background: #f8f9fa;
+            padding: 1.5rem;
+            border-radius: 12px;
+            margin-bottom: 1rem;
+            border-left: 4px solid #00a5bf;
+        }
+
+        .order-header {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 1rem;
+            padding-bottom: 0.75rem;
+            border-bottom: 2px solid #e9ecef;
+        }
+
+        .order-id {
+            font-family: 'Poppins', sans-serif;
+            font-weight: 600;
+            color: #2d3748;
+        }
+
+        .order-date-text {
+            color: #666;
+            font-size: 0.9rem;
+        }
+
+        .order-items-summary {
+            margin-bottom: 0.75rem;
+        }
+
+        .order-item-line {
+            display: flex;
+            justify-content: space-between;
+            padding: 0.25rem 0;
+            color: #2d3748;
+            font-size: 0.9rem;
+        }
+
+        .order-total-line {
+            display: flex;
+            justify-content: space-between;
+            padding-top: 0.75rem;
+            margin-top: 0.75rem;
+            border-top: 2px solid #e9ecef;
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #2d3748;
+        }
+
+        .empty-message {
+            text-align: center;
+            color: #666;
+            font-style: italic;
+            padding: 2rem;
+        }
+    </style>
+</head>
+<body>
+    <header class="header">
+        <div class="container">
+            <h1 class="logo"><a href="index.html" style="color: inherit; text-decoration: none;">ShopTodo</a></h1>
+            <nav class="nav">
+                <div class="language-switcher">
+                    <button id="lang-en" class="lang-btn" data-lang="en">EN</button>
+                    <button id="lang-ja" class="lang-btn active" data-lang="ja">JP</button>
+                </div>
+                <div id="user-info" class="user-info" style="display: none;">
+                    <a href="user-profile.html" id="username" class="user-link"></a>
+                    <button id="logout-btn" class="btn btn-secondary" data-i18n="logout">ログアウト</button>
+                </div>
+            </nav>
+        </div>
+    </header>
+
+    <main class="main">
+        <div class="container">
+            <div class="profile-container">
+                <a href="index.html" class="back-link">
+                    <i class="fas fa-arrow-left"></i>
+                    <span data-i18n="back_to_shop">ショップに戻る</span>
+                </a>
+
+                <h1 class="page-title" data-i18n="user_profile">ユーザー情報</h1>
+
+                <!-- プロファイル編集 -->
+                <section class="profile-section">
+                    <h2><i class="fas fa-user"></i> <span data-i18n="user_profile">ユーザー情報</span></h2>
+                    <form id="profile-form" class="profile-form">
+                        <div class="form-group">
+                            <label for="display-name" data-i18n="display_name">名前</label>
+                            <input type="text" id="display-name" name="displayName">
+                        </div>
+                        <div class="form-group">
+                            <label for="phone" data-i18n="phone_number">電話番号</label>
+                            <input type="tel" id="phone" name="phone">
+                        </div>
+                        <div class="form-group">
+                            <label for="payment-method" data-i18n="preferred_payment">お支払い方法</label>
+                            <select id="payment-method" name="paymentMethod">
+                                <option value="">-- 選択してください --</option>
+                                <option value="credit_card" data-i18n="credit_card">クレジットカード</option>
+                                <option value="bank_transfer" data-i18n="bank_transfer">銀行振込</option>
+                                <option value="cash_on_delivery" data-i18n="cash_on_delivery">代金引換</option>
+                            </select>
+                        </div>
+                        <div class="profile-actions">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save"></i> <span data-i18n="save">保存</span>
+                            </button>
+                        </div>
+                    </form>
+                </section>
+
+                <!-- メモ -->
+                <section class="profile-section">
+                    <h2><i class="fas fa-sticky-note"></i> <span data-i18n="favorite_memo">お気に入り商品メモ</span></h2>
+                    <div class="todo-input-group">
+                        <input type="text" id="todo-input" placeholder="メモを追加..." class="todo-input" data-i18n-placeholder="memo_placeholder">
+                        <button id="add-todo-btn" class="btn btn-primary" data-i18n="add">追加</button>
+                    </div>
+                    <ul id="todo-list" class="todo-list">
+                        <!-- ToDoアイテムが動的に表示される -->
+                    </ul>
+                </section>
+
+                <!-- 購入履歴 -->
+                <section class="profile-section">
+                    <h2><i class="fas fa-history"></i> <span data-i18n="purchase_history">購入履歴</span></h2>
+                    <div id="order-history-list">
+                        <!-- 注文履歴が動的に表示される -->
+                    </div>
+                </section>
+            </div>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <p data-i18n="footer_text">&copy; 2025 ShopTodo - E2Eテスト練習用アプリケーション</p>
+        </div>
+    </footer>
+
+    <script src="app.js"></script>
+    <script src="user-profile.js"></script>
+</body>
+</html>

--- a/user-profile.js
+++ b/user-profile.js
@@ -1,0 +1,311 @@
+// User Profile Page Manager
+class UserProfileManager {
+    constructor(appState) {
+        this.appState = appState;
+        this.checkAuth();
+        this.initializeEventListeners();
+        this.updateUI();
+    }
+
+    checkAuth() {
+        // Redirect to index if not logged in
+        if (!this.appState.currentUser) {
+            window.location.href = 'index.html';
+            return;
+        }
+    }
+
+    initializeEventListeners() {
+        // Language switcher
+        document.getElementById('lang-en').addEventListener('click', () => {
+            this.switchLanguage('en');
+        });
+
+        document.getElementById('lang-ja').addEventListener('click', () => {
+            this.switchLanguage('ja');
+        });
+
+        // Logout
+        document.getElementById('logout-btn').addEventListener('click', () => {
+            this.appState.logout();
+            window.location.href = 'index.html';
+        });
+
+        // Profile form
+        document.getElementById('profile-form').addEventListener('submit', (e) => {
+            this.handleProfileSubmit(e);
+        });
+
+        // Todo
+        document.getElementById('add-todo-btn').addEventListener('click', () => {
+            this.addTodo();
+        });
+
+        document.getElementById('todo-input').addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                this.addTodo();
+            }
+        });
+    }
+
+    updateUI() {
+        this.updateLanguageUI();
+        this.updateAuthUI();
+        this.loadProfileData();
+        this.renderTodos();
+        this.renderOrderHistory();
+    }
+
+    switchLanguage(language) {
+        this.appState.setLanguage(language);
+        this.updateLanguageUI();
+        this.renderTodos();
+        this.renderOrderHistory();
+    }
+
+    updateLanguageUI() {
+        const currentLang = this.appState.currentLanguage;
+
+        // Update language buttons
+        document.querySelectorAll('.lang-btn').forEach(btn => {
+            btn.classList.remove('active');
+        });
+        document.getElementById(`lang-${currentLang}`).classList.add('active');
+
+        // Update data-i18n elements
+        document.querySelectorAll('[data-i18n]').forEach(element => {
+            const key = element.getAttribute('data-i18n');
+            if (i18n[currentLang] && i18n[currentLang][key]) {
+                element.textContent = i18n[currentLang][key];
+            }
+        });
+
+        // Update placeholders
+        document.querySelectorAll('[data-i18n-placeholder]').forEach(element => {
+            const key = element.getAttribute('data-i18n-placeholder');
+            if (i18n[currentLang] && i18n[currentLang][key]) {
+                element.setAttribute('placeholder', i18n[currentLang][key]);
+            }
+        });
+
+        // Update page title
+        document.title = this.t('user_profile') + ' - ShopTodo';
+
+        // Update html lang attribute
+        document.documentElement.lang = currentLang;
+
+        // Update select options
+        this.updateSelectOptions();
+    }
+
+    updateSelectOptions() {
+        const paymentSelect = document.getElementById('payment-method');
+        const options = paymentSelect.querySelectorAll('option[data-i18n]');
+        options.forEach(option => {
+            const key = option.getAttribute('data-i18n');
+            if (i18n[this.appState.currentLanguage][key]) {
+                option.textContent = i18n[this.appState.currentLanguage][key];
+            }
+        });
+    }
+
+    t(key) {
+        return i18n[this.appState.currentLanguage][key] || key;
+    }
+
+    updateAuthUI() {
+        const userInfo = document.getElementById('user-info');
+        const username = document.getElementById('username');
+
+        if (this.appState.currentUser) {
+            userInfo.style.display = 'flex';
+            username.textContent = this.appState.currentUser.username;
+        }
+    }
+
+    loadProfileData() {
+        const profile = this.appState.getProfile();
+        if (profile) {
+            document.getElementById('display-name').value = profile.displayName || '';
+            document.getElementById('phone').value = profile.phone || '';
+            document.getElementById('payment-method').value = profile.paymentMethod || '';
+        }
+    }
+
+    handleProfileSubmit(e) {
+        e.preventDefault();
+
+        const profileData = {
+            displayName: document.getElementById('display-name').value.trim(),
+            phone: document.getElementById('phone').value.trim(),
+            paymentMethod: document.getElementById('payment-method').value
+        };
+
+        if (this.appState.saveProfile(profileData)) {
+            this.showMessage(this.t('profile_saved'), 'success');
+        }
+    }
+
+    addTodo() {
+        const input = document.getElementById('todo-input');
+        const text = input.value.trim();
+
+        if (text) {
+            this.appState.addTodo(text);
+            input.value = '';
+            this.renderTodos();
+            this.showMessage(this.t('memo_added'), 'success');
+        }
+    }
+
+    renderTodos() {
+        const todoList = document.getElementById('todo-list');
+        todoList.innerHTML = '';
+
+        if (this.appState.todos.length === 0) {
+            todoList.innerHTML = `<li class="todo-item"><span class="todo-text">${this.t('memo_empty')}</span></li>`;
+            return;
+        }
+
+        this.appState.todos.forEach(todo => {
+            const todoItem = document.createElement('li');
+            todoItem.className = 'todo-item';
+            const toggleTitle = todo.completed ? this.t('incomplete') : this.t('complete');
+            todoItem.innerHTML = `
+                <span class="todo-text ${todo.completed ? 'completed' : ''}">${todo.text}</span>
+                <div class="todo-controls">
+                    <button class="todo-btn" onclick="profileManager.toggleTodo(${todo.id})" title="${toggleTitle}">
+                        ${todo.completed ? '↩️' : '✅'}
+                    </button>
+                    <button class="todo-btn" onclick="profileManager.deleteTodo(${todo.id})" title="${this.t('delete')}">🗑️</button>
+                </div>
+            `;
+            todoList.appendChild(todoItem);
+        });
+    }
+
+    toggleTodo(todoId) {
+        this.appState.toggleTodo(todoId);
+        this.renderTodos();
+    }
+
+    deleteTodo(todoId) {
+        this.appState.deleteTodo(todoId);
+        this.renderTodos();
+        this.showMessage(this.t('memo_deleted'), 'success');
+    }
+
+    getProductName(japaneseName) {
+        const currentLang = this.appState.currentLanguage;
+        if (currentLang === 'en' && i18n.ja.product_names[japaneseName]) {
+            return i18n.ja.product_names[japaneseName];
+        }
+        return japaneseName;
+    }
+
+    renderOrderHistory() {
+        const historyList = document.getElementById('order-history-list');
+        historyList.innerHTML = '';
+
+        if (this.appState.orders.length === 0) {
+            historyList.innerHTML = `<div class="empty-message">${this.t('no_orders')}</div>`;
+            return;
+        }
+
+        const sortedOrders = [...this.appState.orders].sort((a, b) => b.id - a.id);
+
+        sortedOrders.forEach(order => {
+            const orderDiv = document.createElement('div');
+            orderDiv.className = 'order-history-item';
+
+            const orderDate = new Date(order.date).toLocaleDateString(
+                this.appState.currentLanguage === 'ja' ? 'ja-JP' : 'en-US'
+            );
+
+            let itemsHTML = '';
+            order.items.forEach(item => {
+                const itemName = this.getProductName(item.name);
+                itemsHTML += `
+                    <div class="order-item-line">
+                        <span>${itemName} × ${item.quantity}</span>
+                        <span>¥${(item.price * item.quantity).toLocaleString()}</span>
+                    </div>
+                `;
+            });
+
+            orderDiv.innerHTML = `
+                <div class="order-header">
+                    <div class="order-id">${this.t('order_number')}: ${order.id}</div>
+                    <div class="order-date-text">${this.t('order_date')}: ${orderDate}</div>
+                </div>
+                <div class="order-items-summary">
+                    ${itemsHTML}
+                </div>
+                <div class="order-total-line">
+                    <span>${this.t('total')}:</span>
+                    <span>¥${order.total.toLocaleString()}</span>
+                </div>
+            `;
+
+            historyList.appendChild(orderDiv);
+        });
+    }
+
+    showMessage(message, type = 'info') {
+        const existingMessage = document.querySelector('.message');
+        if (existingMessage) {
+            existingMessage.remove();
+        }
+
+        const messageDiv = document.createElement('div');
+        messageDiv.className = `message message-${type}`;
+        messageDiv.style.cssText = `
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            background: ${type === 'success' ? '#d4edda' : type === 'error' ? '#f8d7da' : '#d1ecf1'};
+            color: ${type === 'success' ? '#155724' : type === 'error' ? '#721c24' : '#0c5460'};
+            padding: 12px 20px;
+            border-radius: 4px;
+            border: 1px solid ${type === 'success' ? '#c3e6cb' : type === 'error' ? '#f5c6cb' : '#bee5eb'};
+            z-index: 1001;
+            font-size: 14px;
+            max-width: 300px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        `;
+        messageDiv.textContent = message;
+
+        document.body.appendChild(messageDiv);
+
+        setTimeout(() => {
+            messageDiv.remove();
+        }, 3000);
+    }
+}
+
+// Initialize
+let profileManager;
+
+document.addEventListener('DOMContentLoaded', () => {
+    // appState is loaded from app.js
+    if (typeof appState !== 'undefined') {
+        profileManager = new UserProfileManager(appState);
+    } else {
+        // If appState is not ready yet, wait for it
+        const checkAppState = setInterval(() => {
+            if (typeof appState !== 'undefined') {
+                clearInterval(checkAppState);
+                profileManager = new UserProfileManager(appState);
+            }
+        }, 100);
+
+        // Timeout after 5 seconds
+        setTimeout(() => {
+            clearInterval(checkAppState);
+            if (typeof appState === 'undefined') {
+                window.location.href = 'index.html';
+            }
+        }, 5000);
+    }
+});


### PR DESCRIPTION
## Summary
- ユーザープロファイルページを新規作成
- ヘッダーのユーザー名をクリック可能なリンクに変更
- メモ機能をサイドバーからプロファイルページへ移動
- ユーザー情報（名前、電話番号、支払い方法）の編集機能を追加
- 購入履歴の表示機能を追加

## Changes
- `user-profile.html`: プロファイルページのHTML
- `user-profile.js`: プロファイルページのJavaScript
- `app.js`: プロファイルデータ構造とi18n翻訳を追加
- `index.html`: ヘッダーリンクを更新、Todoセクションを削除
- `styles.css`: ユーザーリンクのスタイルを追加
- `e2e/features/todo.feature`: プロファイルページへのナビゲーションを追加
- `e2e/step-definitions/todo.steps.ts`: プロファイルページのステップ定義を追加

## Test plan
- [x] E2E smoke tests pass (15/15)
- [ ] ユーザー名をクリックしてプロファイルページに遷移できる
- [ ] プロファイル情報を編集・保存できる
- [ ] メモの追加・完了・削除ができる
- [ ] 購入履歴が正しく表示される
- [ ] 日本語/英語の切り替えが正しく動作する

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)