### PR TITLE
Fix search to support both Japanese and English product names

### DIFF
--- a/app.js
+++ b/app.js
@@ -568,11 +568,14 @@ class AppState {
     filterProducts(searchTerm, category, sortBy) {
         let filtered = [...this.products];
 
-        // 検索フィルタ
+        // 検索フィルタ（日本語名と英語名の両方を検索）
         if (searchTerm) {
-            filtered = filtered.filter(product =>
-                product.name.toLowerCase().includes(searchTerm.toLowerCase())
-            );
+            const searchLower = searchTerm.toLowerCase();
+            filtered = filtered.filter(product => {
+                const japaneseName = product.name.toLowerCase();
+                const englishName = (i18n.ja.product_names[product.name] || '').toLowerCase();
+                return japaneseName.includes(searchLower) || englishName.includes(searchLower);
+            });
         }
 
         // カテゴリフィルタ

--- a/e2e/features/search.feature
+++ b/e2e/features/search.feature
@@ -9,9 +9,14 @@ Feature: Product Search, Filter, and Sort
     And the language is set to English
 
   @smoke @search
-  Scenario: Search for a product by name
+  Scenario: Search for a product by Japanese name
     When the user searches for "スマートフォン"
     Then the search results should contain "Smartphone"
+
+  @smoke @search
+  Scenario: Search for a product by English name
+    When the user searches for "Jeans"
+    Then the search results should contain "Jeans"
 
   @smoke @search @filter
   Scenario: Filter products by category


### PR DESCRIPTION
## Summary
- 検索機能が日本語名と英語名の両方を検索するように修正
- `filterProducts()` を更新し、`product.name`（日本語）と`i18n.ja.product_names`（英語訳）の両方を検索対象に
- 英語名検索のE2Eテストを追加

## Changes
- `app.js`: `filterProducts()` メソッドを更新
- `e2e/features/search.feature`: 英語名検索のテストシナリオを追加

## Test Results
- Unit tests: 114 passed
- E2E search tests: 3 passed (including new English search test)

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)