### PR TITLE
Add SRI and clickjacking protection (V6, V7)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,16 +3,24 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Security: Clickjacking Protection via CSP -->
+    <meta http-equiv="Content-Security-Policy" content="frame-ancestors 'self';">
     <title data-i18n="title">ShopTodo - E2Eテスト練習用アプリ</title>
-    <!-- Google Fonts -->
+    <!-- Google Fonts (SRI not supported - dynamically generated) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <!-- Font Awesome -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <!-- Font Awesome with SRI -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" crossorigin="anonymous" referrerpolicy="no-referrer">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <!-- Security: Frame-busting script for clickjacking protection (legacy browsers) -->
+    <script>
+        if (window.top !== window.self) {
+            window.top.location = window.self.location;
+        }
+    </script>
     <header class="header">
         <div class="container">
             <h1 class="logo">ShopTodo</h1>

--- a/tests/security/README.md
+++ b/tests/security/README.md
@@ -94,15 +94,18 @@ npm run test:security:config     # 設定 (Medium)
 
 ### Medium (計画的な対応)
 
-#### V6: SRI未設定
-- **場所**: `index.html` CDNリソース
+#### ~~V6: SRI未設定~~ ✅ FIXED
+- **場所**: `index.html`, `user-profile.html` CDNリソース
 - **影響**: CDN侵害時のリスク
-- **対策**: Subresource Integrity (SRI) 属性の追加
+- **対策**: ✅ Font Awesome に `integrity` と `crossorigin` 属性を追加
+- **修正日**: Issue #35
+- **注意**: Google Fonts は動的生成のためSRI非対応
 
-#### V7: クリックジャッキング保護なし
+#### ~~V7: クリックジャッキング保護なし~~ ✅ FIXED
 - **場所**: アプリケーション全体
 - **影響**: UI リドレス攻撃のリスク
-- **対策**: X-Frame-Options または CSP frame-ancestors の設定
+- **対策**: ✅ CSP `frame-ancestors 'self'` メタタグ + JavaScript frame-busting
+- **修正日**: Issue #35
 
 ## テスト結果の解釈
 

--- a/tests/security/WSTG-CLNT/clnt-02-clickjacking.test.js
+++ b/tests/security/WSTG-CLNT/clnt-02-clickjacking.test.js
@@ -33,7 +33,7 @@ describe('WSTG-CLNT-02: Clickjacking Testing', () => {
   });
 
   describe('Frame Protection Headers', () => {
-    test('VULNERABILITY: index.html does not set X-Frame-Options', () => {
+    test('FIXED: index.html has clickjacking protection', () => {
       // Read index.html to check for frame busting
       const indexPath = path.join(__dirname, '../../../index.html');
       const indexHtml = fs.readFileSync(indexPath, 'utf8');
@@ -46,12 +46,31 @@ describe('WSTG-CLNT-02: Clickjacking Testing', () => {
                               indexHtml.includes('self !== top') ||
                               indexHtml.includes('window.top');
 
-      // Document that protection is missing
-      expect(hasFrameAncestors).toBe(false);
-      expect(hasFrameBusting).toBe(false);
+      // Verify that protection is in place
+      expect(hasFrameAncestors).toBe(true);
+      expect(hasFrameBusting).toBe(true);
 
-      console.log('SECURITY WARNING: No clickjacking protection detected');
-      console.log('Recommendation: Add X-Frame-Options header or CSP frame-ancestors');
+      console.log('SECURITY: Clickjacking protection detected');
+      console.log('- CSP frame-ancestors: ' + hasFrameAncestors);
+      console.log('- JavaScript frame-busting: ' + hasFrameBusting);
+    });
+
+    test('FIXED: user-profile.html has clickjacking protection', () => {
+      // Read user-profile.html to check for frame busting
+      const profilePath = path.join(__dirname, '../../../user-profile.html');
+      const profileHtml = fs.readFileSync(profilePath, 'utf8');
+
+      // Check for meta tag frame protection (CSP frame-ancestors)
+      const hasFrameAncestors = profileHtml.includes('frame-ancestors');
+
+      // Check for JavaScript frame busting code
+      const hasFrameBusting = profileHtml.includes('top.location') ||
+                              profileHtml.includes('self !== top') ||
+                              profileHtml.includes('window.top');
+
+      // Verify that protection is in place
+      expect(hasFrameAncestors).toBe(true);
+      expect(hasFrameBusting).toBe(true);
     });
   });
 

--- a/tests/security/WSTG-CONF/conf-01-cdn-integrity.test.js
+++ b/tests/security/WSTG-CONF/conf-01-cdn-integrity.test.js
@@ -72,27 +72,27 @@ describe('WSTG-CONF-01: CDN Integrity Testing', () => {
   });
 
   describe('Font Awesome CDN', () => {
-    test('Document Font Awesome SRI status', () => {
+    test('FIXED: Font Awesome has SRI attributes', () => {
       const hasFontAwesome = indexHtml.includes('font-awesome') ||
                              indexHtml.includes('fontawesome');
 
-      if (!hasFontAwesome) {
-        console.log('Font Awesome not detected');
-        return;
-      }
+      expect(hasFontAwesome).toBe(true);
 
       const fontAwesomeRegex = /<link[^>]+href=["']([^"']*font-?awesome[^"']*)["'][^>]*>/gi;
       const matches = [...indexHtml.matchAll(fontAwesomeRegex)];
 
+      expect(matches.length).toBeGreaterThan(0);
+
       matches.forEach(match => {
         const hasIntegrity = match[0].includes('integrity=');
-        if (!hasIntegrity) {
-          console.log('SECURITY WARNING: Font Awesome resource lacks SRI:', match[1]);
-        }
-      });
+        const hasCrossorigin = match[0].includes('crossorigin=');
 
-      // Document: Font Awesome resources should have SRI for security
-      expect(matches.length).toBeGreaterThanOrEqual(0);
+        // Verify SRI is now in place
+        expect(hasIntegrity).toBe(true);
+        expect(hasCrossorigin).toBe(true);
+
+        console.log('SECURITY: Font Awesome has SRI:', match[1]);
+      });
     });
   });
 

--- a/user-profile.html
+++ b/user-profile.html
@@ -3,13 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Security: Clickjacking Protection via CSP -->
+    <meta http-equiv="Content-Security-Policy" content="frame-ancestors 'self';">
     <title data-i18n="user_profile">ユーザー情報 - ShopTodo</title>
-    <!-- Google Fonts -->
+    <!-- Google Fonts (SRI not supported - dynamically generated) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <!-- Font Awesome -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <!-- Font Awesome with SRI -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" crossorigin="anonymous" referrerpolicy="no-referrer">
     <link rel="stylesheet" href="styles.css">
     <style>
         .profile-container {
@@ -215,6 +217,12 @@
     </style>
 </head>
 <body>
+    <!-- Security: Frame-busting script for clickjacking protection (legacy browsers) -->
+    <script>
+        if (window.top !== window.self) {
+            window.top.location = window.self.location;
+        }
+    </script>
     <header class="header">
         <div class="container">
             <h1 class="logo"><a href="index.html" style="color: inherit; text-decoration: none;">ShopTodo</a></h1>


### PR DESCRIPTION
## Summary
Fix medium-severity security vulnerabilities V6 and V7 identified in security test suite.

## Changes

### V6: Subresource Integrity (SRI)
Added to `index.html` and `user-profile.html`:
```html
<link rel="stylesheet" 
      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" 
      integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" 
      crossorigin="anonymous" 
      referrerpolicy="no-referrer">
```

**Note**: Google Fonts does not support SRI as content is dynamically generated based on browser.

### V7: Clickjacking Protection
Added to `index.html` and `user-profile.html`:

1. **CSP Meta Tag**:
```html
<meta http-equiv="Content-Security-Policy" content="frame-ancestors 'self';">
```

2. **JavaScript Frame-busting** (for legacy browsers):
```html
<script>
    if (window.top !== window.self) {
        window.top.location = window.self.location;
    }
</script>
```

## Security Impact
| Vulnerability | Before | After |
|--------------|--------|-------|
| V6: SRI | No integrity check | Font Awesome verified via SHA-512 |
| V7: Clickjacking | No protection | CSP + frame-busting |

Fixes #35

## Test plan
- [x] All 232 tests pass
- [ ] CI workflow completes successfully
- [ ] Manual verification: page loads correctly with Font Awesome icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)