### PR TITLE
Change known vulnerability tests to test.skip

### DIFF
--- a/tests/security/README.md
+++ b/tests/security/README.md
@@ -111,10 +111,29 @@ npm run test:security:config     # 設定 (Medium)
 
 テストは以下のパターンで分類されています:
 
-- `VULNERABILITY:` - 確認された脆弱性
+- `VULNERABILITY:` - 確認された脆弱性（`test.skip` でスキップ）
+- `FIXED:` - 修正済みの脆弱性（テストがパスする）
 - `GOOD:` - 適切に実装されている機能
 - `PARTIAL:` - 一部対策済みだが改善の余地あり
 - `Document:` - 文書化目的（推奨事項）
+
+### test.skip について
+
+未修正の既知の脆弱性を文書化するテストは `test.skip()` を使用してスキップされています。
+これにより:
+
+1. **テスト結果が誤解を招かない**: 脆弱性が存在するにもかかわらずテストがパスすることを防ぎます
+2. **可視性の確保**: スキップされたテストは出力に表示され、未対応の脆弱性を認識できます
+3. **修正後の再有効化**: 脆弱性を修正したら、`test.skip` を `test` に戻すことで検証できます
+
+```bash
+# テスト実行時の出力例
+PASS  tests/security/WSTG-BUSL/busl-01-cart-manipulation.test.js
+  WSTG-BUSL-01: Cart Manipulation Testing
+    Price Tampering via localStorage
+      ○ skipped VULNERABILITY: Cart prices can be tampered via localStorage
+      ○ skipped Cart total reflects tampered prices
+```
 
 ## 参考資料
 

--- a/tests/security/WSTG-ATHN/athn-01-credentials.test.js
+++ b/tests/security/WSTG-ATHN/athn-01-credentials.test.js
@@ -20,7 +20,7 @@ describe('WSTG-ATHN-01: Authentication Credentials Testing', () => {
   });
 
   describe('Hardcoded Credentials', () => {
-    test('VULNERABILITY: Application uses hardcoded credentials', () => {
+    test.skip('VULNERABILITY: Application uses hardcoded credentials', () => {
       // Document: The application has hardcoded demo credentials
       // Location: app.js login method
       const validCredentials = { username: 'demo', password: 'password' };
@@ -92,7 +92,7 @@ describe('WSTG-ATHN-01: Authentication Credentials Testing', () => {
   });
 
   describe('Brute Force Protection', () => {
-    test('VULNERABILITY: No rate limiting or lockout mechanism', () => {
+    test.skip('VULNERABILITY: No rate limiting or lockout mechanism', () => {
       // Attempt multiple logins
       const attempts = [];
       for (let i = 0; i < 100; i++) {
@@ -113,7 +113,7 @@ describe('WSTG-ATHN-01: Authentication Credentials Testing', () => {
   });
 
   describe('Password Complexity', () => {
-    test('VULNERABILITY: Weak password accepted', () => {
+    test.skip('VULNERABILITY: Weak password accepted', () => {
       // The demo account uses "password" which is extremely weak
       // For a real application, password complexity should be enforced
 

--- a/tests/security/WSTG-BUSL/busl-01-cart-manipulation.test.js
+++ b/tests/security/WSTG-BUSL/busl-01-cart-manipulation.test.js
@@ -18,7 +18,7 @@ describe('WSTG-BUSL-01: Cart Manipulation Testing', () => {
   });
 
   describe('Price Tampering via localStorage', () => {
-    test('VULNERABILITY: Cart prices can be tampered via localStorage', () => {
+    test.skip('VULNERABILITY: Cart prices can be tampered via localStorage', () => {
       // Add product with original price
       const productId = 1; // Smartphone - 89800 yen
       appState.addToCart(productId);
@@ -42,7 +42,7 @@ describe('WSTG-BUSL-01: Cart Manipulation Testing', () => {
       console.log('Tampered price:', newAppState.cart[0].price);
     });
 
-    test('Cart total reflects tampered prices', () => {
+    test.skip('Cart total reflects tampered prices', () => {
       appState.addToCart(1); // 89800 yen
 
       // Tamper price
@@ -62,7 +62,7 @@ describe('WSTG-BUSL-01: Cart Manipulation Testing', () => {
   });
 
   describe('Quantity Manipulation', () => {
-    test('VULNERABILITY: Negative quantity can be set', () => {
+    test.skip('VULNERABILITY: Negative quantity can be set', () => {
       appState.addToCart(1);
 
       // Attempt to set negative quantity via localStorage
@@ -78,7 +78,7 @@ describe('WSTG-BUSL-01: Cart Manipulation Testing', () => {
       console.log('SECURITY WARNING: Negative quantities accepted');
     });
 
-    test('VULNERABILITY: Extremely large quantity can be set', () => {
+    test.skip('VULNERABILITY: Extremely large quantity can be set', () => {
       appState.addToCart(1);
 
       const cart = JSON.parse(localStorage.getItem('cart'));
@@ -93,7 +93,7 @@ describe('WSTG-BUSL-01: Cart Manipulation Testing', () => {
   });
 
   describe('Product ID Manipulation', () => {
-    test('VULNERABILITY: Non-existent product ID can be added', () => {
+    test.skip('VULNERABILITY: Non-existent product ID can be added', () => {
       // Manually add cart item with fake product ID
       const fakeCart = [{
         id: 99999,

--- a/tests/security/WSTG-BUSL/busl-02-checkout-bypass.test.js
+++ b/tests/security/WSTG-BUSL/busl-02-checkout-bypass.test.js
@@ -26,7 +26,7 @@ describe('WSTG-BUSL-02: Checkout Bypass Testing', () => {
       // This test documents that empty cart state is detectable
     });
 
-    test('VULNERABILITY: Orders can be created with empty cart via localStorage', () => {
+    test.skip('VULNERABILITY: Orders can be created with empty cart via localStorage', () => {
       // Directly create order without cart
       const fakeOrder = {
         id: Date.now(),
@@ -55,7 +55,7 @@ describe('WSTG-BUSL-02: Checkout Bypass Testing', () => {
   });
 
   describe('Shipping Validation Bypass', () => {
-    test('VULNERABILITY: Orders can be created with empty shipping info', () => {
+    test.skip('VULNERABILITY: Orders can be created with empty shipping info', () => {
       appState.addToCart(1);
 
       // Create order with empty shipping
@@ -82,7 +82,7 @@ describe('WSTG-BUSL-02: Checkout Bypass Testing', () => {
       // Recommendation: Validate shipping info server-side
     });
 
-    test('VULNERABILITY: Invalid email format accepted in orders', () => {
+    test.skip('VULNERABILITY: Invalid email format accepted in orders', () => {
       const invalidEmails = [
         'not-an-email',
         '@nodomain',
@@ -107,7 +107,7 @@ describe('WSTG-BUSL-02: Checkout Bypass Testing', () => {
   });
 
   describe('Payment Method Bypass', () => {
-    test('VULNERABILITY: Invalid payment method can be stored', () => {
+    test.skip('VULNERABILITY: Invalid payment method can be stored', () => {
       appState.addToCart(1);
 
       const orderWithInvalidPayment = {
@@ -135,7 +135,7 @@ describe('WSTG-BUSL-02: Checkout Bypass Testing', () => {
   });
 
   describe('Order Total Manipulation', () => {
-    test('VULNERABILITY: Order total can be set to any value', () => {
+    test.skip('VULNERABILITY: Order total can be set to any value', () => {
       appState.addToCart(1); // 89800 yen
 
       const orderWithTamperedTotal = {
@@ -164,7 +164,7 @@ describe('WSTG-BUSL-02: Checkout Bypass Testing', () => {
   });
 
   describe('Order History Manipulation', () => {
-    test('VULNERABILITY: Fake orders can be injected', () => {
+    test.skip('VULNERABILITY: Fake orders can be injected', () => {
       // Inject fake orders with any data
       const fakeOrders = [
         {

--- a/tests/security/WSTG-CLNT/clnt-01-localstorage-security.test.js
+++ b/tests/security/WSTG-CLNT/clnt-01-localstorage-security.test.js
@@ -18,7 +18,7 @@ describe('WSTG-CLNT-01: localStorage Security Testing', () => {
   });
 
   describe('Data Persistence Risks', () => {
-    test('VULNERABILITY: All data stored in localStorage persists indefinitely', () => {
+    test.skip('VULNERABILITY: All data stored in localStorage persists indefinitely', () => {
       appState.login('demo', 'password');
       appState.addTodo('Sensitive task');
       appState.addToCart(1);
@@ -47,7 +47,7 @@ describe('WSTG-CLNT-01: localStorage Security Testing', () => {
   });
 
   describe('Data Tampering Risks', () => {
-    test('VULNERABILITY: Any JavaScript can modify localStorage', () => {
+    test.skip('VULNERABILITY: Any JavaScript can modify localStorage', () => {
       appState.login('demo', 'password');
 
       // Simulate malicious script modifying data
@@ -60,7 +60,7 @@ describe('WSTG-CLNT-01: localStorage Security Testing', () => {
       // No integrity checks on localStorage data
     });
 
-    test('VULNERABILITY: localStorage data is not encrypted', () => {
+    test.skip('VULNERABILITY: localStorage data is not encrypted', () => {
       appState.login('demo', 'password');
       appState.addTodo('Secret information');
 
@@ -111,7 +111,7 @@ describe('WSTG-CLNT-01: localStorage Security Testing', () => {
   });
 
   describe('Sensitive Data Exposure', () => {
-    test('VULNERABILITY: User preferences stored without protection', () => {
+    test.skip('VULNERABILITY: User preferences stored without protection', () => {
       appState.login('demo', 'password');
       localStorage.setItem('language', 'ja');
 
@@ -120,7 +120,7 @@ describe('WSTG-CLNT-01: localStorage Security Testing', () => {
       expect(localStorage.getItem('currentUser')).not.toBeNull();
     });
 
-    test('VULNERABILITY: Order history with PII can be stored', () => {
+    test.skip('VULNERABILITY: Order history with PII can be stored', () => {
       const orderWithPII = {
         id: Date.now(),
         shipping: {

--- a/tests/security/WSTG-SESS/sess-01-session-management.test.js
+++ b/tests/security/WSTG-SESS/sess-01-session-management.test.js
@@ -17,7 +17,7 @@ describe('WSTG-SESS-01: Session Management Testing', () => {
   });
 
   describe('Session Token Analysis', () => {
-    test('VULNERABILITY: No session token - uses localStorage JSON object only', () => {
+    test.skip('VULNERABILITY: No session token - uses localStorage JSON object only', () => {
       appState.login('demo', 'password');
 
       // App uses localStorage JSON object for authentication
@@ -33,7 +33,7 @@ describe('WSTG-SESS-01: Session Management Testing', () => {
       console.log('SECURITY WARNING: Session relies on manipulable localStorage');
     });
 
-    test('VULNERABILITY: Session can be created without authentication', () => {
+    test.skip('VULNERABILITY: Session can be created without authentication', () => {
       // Directly set currentUser without login
       localStorage.setItem('currentUser', JSON.stringify({ username: 'admin' }));
 
@@ -45,7 +45,7 @@ describe('WSTG-SESS-01: Session Management Testing', () => {
       // Any script can hijack session by setting localStorage
     });
 
-    test('VULNERABILITY: No session token randomness', () => {
+    test.skip('VULNERABILITY: No session token randomness', () => {
       appState.login('demo', 'password');
 
       // Session "token" is predictable (just user object)
@@ -59,7 +59,7 @@ describe('WSTG-SESS-01: Session Management Testing', () => {
   });
 
   describe('Session Fixation', () => {
-    test('VULNERABILITY: Session identifier does not change after login', () => {
+    test.skip('VULNERABILITY: Session identifier does not change after login', () => {
       // Set a "session" before login
       localStorage.setItem('currentUser', JSON.stringify({ username: 'victim' }));
 
@@ -113,7 +113,7 @@ describe('WSTG-SESS-01: Session Management Testing', () => {
   });
 
   describe('Session Timeout', () => {
-    test('VULNERABILITY: No session timeout implemented', () => {
+    test.skip('VULNERABILITY: No session timeout implemented', () => {
       appState.login('demo', 'password');
 
       // Set a timestamp to simulate old session


### PR DESCRIPTION
## Summary
- Convert 24 VULNERABILITY tests to `test.skip()` to prevent false positives
- Update security test README with `test.skip` explanation

## Changes

### Test files modified:
- **WSTG-BUSL**: `busl-01-cart-manipulation.test.js`, `busl-02-checkout-bypass.test.js` (11 tests)
- **WSTG-ATHN**: `athn-01-credentials.test.js` (3 tests)
- **WSTG-SESS**: `sess-01-session-management.test.js` (5 tests)
- **WSTG-CLNT**: `clnt-01-localstorage-security.test.js` (5 tests)

### Why this change?
Previously, tests documenting known vulnerabilities would pass even though the underlying security issues were not fixed. This created a misleading test output where all tests appeared green.

Now:
- Unfixed vulnerability tests are **skipped** and clearly visible in output
- When a vulnerability is fixed, change `test.skip` back to `test` to verify the fix
- Test results accurately reflect the security posture

### Test output example:
```
PASS tests/security/WSTG-BUSL/busl-01-cart-manipulation.test.js
  WSTG-BUSL-01: Cart Manipulation Testing
    Price Tampering via localStorage
      ○ skipped VULNERABILITY: Cart prices can be tampered via localStorage
      ○ skipped Cart total reflects tampered prices
```

Fixes #37

## Test plan
- [x] Run `npm run test:security` - 24 skipped, 94 passed
- [x] Verify skipped tests appear in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)