### PR TITLE
a11y: Add focus-visible styles for keyboard navigation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,34 @@
     box-sizing: border-box;
 }
 
+/* アクセシビリティ: フォーカススタイル (WCAG 2.4.7) */
+:focus-visible {
+    outline: 3px solid #005f6b;
+    outline-offset: 2px;
+}
+
+/* ボタンのフォーカススタイル */
+.btn:focus-visible,
+button:focus-visible {
+    outline: 3px solid #005f6b;
+    outline-offset: 2px;
+    box-shadow: 0 0 0 6px rgba(0, 95, 107, 0.3);
+}
+
+/* リンクのフォーカススタイル */
+a:focus-visible {
+    outline: 3px solid #005f6b;
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+/* 白背景上のフォーカススタイル */
+.modal-content :focus-visible,
+.card :focus-visible,
+.product-card :focus-visible {
+    outline-color: #00a5bf;
+}
+
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     line-height: 1.6;
@@ -258,10 +286,15 @@ body {
 }
 
 .search-input:focus, .filter-select:focus {
-    outline: none;
     background: white;
     box-shadow: 0 6px 20px 0 rgba(0, 165, 191, 0.3);
     transform: translateY(-2px);
+}
+
+/* 入力フィールドのフォーカススタイル */
+.search-input:focus-visible, .filter-select:focus-visible {
+    outline: 3px solid #00a5bf;
+    outline-offset: 2px;
 }
 
 .search-input {


### PR DESCRIPTION
## Summary
- キーボードナビゲーション用のフォーカススタイルを追加
- `outline: none` を削除し、WCAG 2.4.7 準拠に

## Changes
- グローバル `:focus-visible` スタイルを追加（3px outline）
- ボタン、リンク用の明確なフォーカススタイル
- 検索/フィルター入力のフォーカススタイル修正

## WCAG Compliance
- **2.4.7 Focus Visible (Level AA)**: キーボードフォーカスが視覚的に確認可能に

## Test
キーボードのTabキーでページ内を移動し、フォーカスが見えることを確認

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)