### PR TITLE
a11y: Add ARIA attributes to modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,10 +41,10 @@
     <main class="main">
         <div class="container">
             <!-- ログインモーダル -->
-            <div id="login-modal" class="modal">
+            <div id="login-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="login-modal-title">
                 <div class="modal-content">
-                    <span class="close">&times;</span>
-                    <h2 data-i18n="login">ログイン</h2>
+                    <button class="close" aria-label="閉じる">&times;</button>
+                    <h2 id="login-modal-title" data-i18n="login">ログイン</h2>
                     <form id="login-form">
                         <div class="form-group">
                             <label for="username-input" data-i18n="username">ユーザー名:</label>
@@ -61,10 +61,10 @@
             </div>
 
             <!-- チェックアウトモーダル -->
-            <div id="checkout-modal" class="modal">
+            <div id="checkout-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="checkout-modal-title">
                 <div class="modal-content checkout-modal-content">
-                    <span class="close" id="checkout-close">&times;</span>
-                    <h2 data-i18n="checkout_title">チェックアウト</h2>
+                    <button class="close" id="checkout-close" aria-label="閉じる">&times;</button>
+                    <h2 id="checkout-modal-title" data-i18n="checkout_title">チェックアウト</h2>
 
                     <!-- ステップインジケーター -->
                     <div class="checkout-steps">
@@ -179,10 +179,10 @@
             </div>
 
             <!-- 注文履歴モーダル -->
-            <div id="order-history-modal" class="modal">
+            <div id="order-history-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="order-history-modal-title">
                 <div class="modal-content">
-                    <span class="close" id="history-close">&times;</span>
-                    <h2 data-i18n="order_history">注文履歴</h2>
+                    <button class="close" id="history-close" aria-label="閉じる">&times;</button>
+                    <h2 id="order-history-modal-title" data-i18n="order_history">注文履歴</h2>
                     <div id="order-history-list" class="order-history-list">
                         <!-- 注文履歴が動的に表示される -->
                     </div>

--- a/styles.css
+++ b/styles.css
@@ -219,6 +219,10 @@ body {
     font-size: 2rem;
     cursor: pointer;
     color: #aaa;
+    background: none;
+    border: none;
+    padding: 0;
+    line-height: 1;
 }
 
 .close:hover {


### PR DESCRIPTION
## Summary
- 全モーダルにARIA属性を追加してスクリーンリーダー対応

## Changes
- `role="dialog"` と `aria-modal="true"` を全モーダルに追加
- `aria-labelledby` でモーダルタイトルと関連付け
- 閉じるボタンを `<span>` から `<button>` に変更
- 閉じるボタンに `aria-label="閉じる"` を追加

## WCAG Compliance
- **4.1.2 Name, Role, Value (Level A)**: スクリーンリーダーがダイアログを正しく認識

## Affected Modals
- login-modal
- checkout-modal
- order-history-modal

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)