### PR TITLE
a11y: Add aria-live regions for status messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -1302,6 +1302,16 @@ class UIManager {
 
         const messageDiv = document.createElement('div');
         messageDiv.className = `message message-${type}`;
+
+        // アクセシビリティ: aria-live リージョン (WCAG 4.1.3)
+        if (type === 'error') {
+            messageDiv.setAttribute('role', 'alert');
+            messageDiv.setAttribute('aria-live', 'assertive');
+        } else {
+            messageDiv.setAttribute('role', 'status');
+            messageDiv.setAttribute('aria-live', 'polite');
+        }
+
         messageDiv.style.cssText = `
             position: fixed;
             top: 20px;

--- a/tests/UIManager.test.js
+++ b/tests/UIManager.test.js
@@ -227,7 +227,8 @@ describe('UIManager', () => {
           cssText: ''
         },
         textContent: '',
-        remove: jest.fn()
+        remove: jest.fn(),
+        setAttribute: jest.fn()
       };
 
       document.createElement = jest.fn(() => mockMessageDiv);
@@ -241,6 +242,8 @@ describe('UIManager', () => {
       expect(document.createElement).toHaveBeenCalledWith('div');
       expect(mockMessageDiv.className).toBe('message message-success');
       expect(mockMessageDiv.textContent).toBe('Test message');
+      expect(mockMessageDiv.setAttribute).toHaveBeenCalledWith('role', 'status');
+      expect(mockMessageDiv.setAttribute).toHaveBeenCalledWith('aria-live', 'polite');
       expect(document.body.appendChild).toHaveBeenCalledWith(mockMessageDiv);
     });
 
@@ -254,7 +257,8 @@ describe('UIManager', () => {
         className: '',
         style: { cssText: '' },
         textContent: '',
-        remove: jest.fn()
+        remove: jest.fn(),
+        setAttribute: jest.fn()
       }));
       document.body.appendChild = jest.fn();
 

--- a/user-profile.js
+++ b/user-profile.js
@@ -260,6 +260,16 @@ class UserProfileManager {
 
         const messageDiv = document.createElement('div');
         messageDiv.className = `message message-${type}`;
+
+        // アクセシビリティ: aria-live リージョン (WCAG 4.1.3)
+        if (type === 'error') {
+            messageDiv.setAttribute('role', 'alert');
+            messageDiv.setAttribute('aria-live', 'assertive');
+        } else {
+            messageDiv.setAttribute('role', 'status');
+            messageDiv.setAttribute('aria-live', 'polite');
+        }
+
         messageDiv.style.cssText = `
             position: fixed;
             top: 20px;


### PR DESCRIPTION
## Summary
- ステータスメッセージにaria-liveリージョンを追加

## Changes
- 成功/情報メッセージ: `role="status"`, `aria-live="polite"`
- エラーメッセージ: `role="alert"`, `aria-live="assertive"`
- ユニットテストを更新

## WCAG Compliance
- **4.1.3 Status Messages (Level AA)**: スクリーンリーダーでメッセージが読み上げられる

## Affected Files
- `app.js` - showMessage関数
- `user-profile.js` - showMessage関数
- `tests/UIManager.test.js` - テスト更新

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)