### PR TITLE
a11y: Add accessibility testing with axe-core

### DIFF
--- a/e2e/features/accessibility.feature
+++ b/e2e/features/accessibility.feature
@@ -1,0 +1,39 @@
+Feature: Accessibility (a11y) Testing
+  As a user with accessibility needs
+  I want the application to be accessible
+  So that I can use it with assistive technologies
+
+  Background:
+    Given the application is available
+
+  @a11y @smoke
+  Scenario: Home page should have no critical accessibility violations
+    When the user is on the home page
+    Then the page should have no critical accessibility violations
+
+  @a11y @smoke
+  Scenario: Login modal should be accessible
+    Given the user is logged out
+    When the user opens the login modal
+    Then the modal should have no critical accessibility violations
+    And the modal should have proper ARIA attributes
+
+  @a11y
+  Scenario: Product catalog should be accessible
+    Given the user is logged in as "demo"
+    When the user views the product catalog
+    Then the product list should have no critical accessibility violations
+
+  @a11y
+  Scenario: Checkout modal should be accessible
+    Given the user is logged in as "demo"
+    And the user has items in the cart
+    When the user opens the checkout modal
+    Then the modal should have no critical accessibility violations
+    And the checkout form should have proper labels
+
+  @a11y
+  Scenario: Skip link should be functional
+    When the user presses Tab key
+    Then the skip link should be visible
+    And the skip link should navigate to main content

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -12,12 +12,26 @@
         "playwright": "^1.40.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.8.0",
         "@cucumber/cucumber": "^10.0.1",
         "@playwright/test": "^1.40.0",
         "@types/node": "^20.8.0",
         "allure-cucumberjs": "^3.4.3",
         "ts-node": "^10.9.0",
         "typescript": "^5.2.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.0.tgz",
+      "integrity": "sha512-70vBT/Ylqpm65RQz2iCG2o0JJCEG/WCNyefTr2xcOcr1CoSee60gNQYUMZZ7YukoKkFLv26I/jjlsvwwp532oQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -549,6 +563,16 @@
         "diff": "^4.0.1",
         "pad-right": "^0.2.2",
         "repeat-string": "^1.6.1"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
+      "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,6 +15,7 @@
     "test:e2e:regression": "cucumber-js --require-module ts-node/register --require 'step-definitions/**/*.ts' --require 'support/**/*.ts' --tags '@regression' --format allure-cucumberjs/reporter --format-options '{\"resultsDir\":\"./allure-results\"}'",
     "test:e2e:parallel": "cucumber-js --require-module ts-node/register --require 'step-definitions/**/*.ts' --require 'support/**/*.ts' --parallel 2 --format allure-cucumberjs/reporter --format-options '{\"resultsDir\":\"./allure-results\"}'",
     "test:e2e:report": "echo 'Test report generation - implement if needed'",
+    "test:a11y": "cucumber-js --require-module ts-node/register --require 'step-definitions/**/*.ts' --require 'support/**/*.ts' --tags '@a11y' --format allure-cucumberjs/reporter --format-options '{\"resultsDir\":\"./allure-results\"}'",
     "install:browsers": "npx playwright install"
   },
   "keywords": [
@@ -27,6 +28,7 @@
   "author": "Claude Code",
   "license": "MIT",
   "devDependencies": {
+    "@axe-core/playwright": "^4.8.0",
     "@cucumber/cucumber": "^10.0.1",
     "@playwright/test": "^1.40.0",
     "@types/node": "^20.8.0",

--- a/e2e/step-definitions/accessibility.steps.ts
+++ b/e2e/step-definitions/accessibility.steps.ts
@@ -1,0 +1,168 @@
+import { Given, When, Then } from '@cucumber/cucumber';
+import { expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { CustomWorld } from '../support/world';
+
+// Given Steps
+Given('the user is logged out', async function(this: CustomWorld) {
+  await this.loginPage.goto();
+  // Check if logged in and logout if necessary
+  const logoutBtn = this.page.locator('#logout-btn');
+  if (await logoutBtn.isVisible()) {
+    await logoutBtn.click();
+    await this.page.waitForTimeout(500);
+  }
+});
+
+Given('the user has items in the cart', async function(this: CustomWorld) {
+  // Add a product to cart
+  const addToCartBtn = this.page.locator('.product-card .btn').first();
+  await addToCartBtn.click();
+  await this.page.waitForTimeout(500);
+});
+
+// When Steps
+When('the user is on the home page', async function(this: CustomWorld) {
+  await this.loginPage.goto();
+  await this.page.waitForTimeout(500);
+});
+
+When('the user opens the login modal', async function(this: CustomWorld) {
+  await this.page.locator('#login-btn').click();
+  await this.page.waitForTimeout(500);
+});
+
+When('the user views the product catalog', async function(this: CustomWorld) {
+  // Products should be visible on the main page
+  await this.page.waitForSelector('.products-grid');
+});
+
+When('the user opens the checkout modal', async function(this: CustomWorld) {
+  await this.page.locator('#checkout-btn').click();
+  await this.page.waitForTimeout(500);
+});
+
+When('the user presses Tab key', async function(this: CustomWorld) {
+  await this.page.keyboard.press('Tab');
+  await this.page.waitForTimeout(200);
+});
+
+// Then Steps
+Then('the page should have no critical accessibility violations', async function(this: CustomWorld) {
+  const accessibilityScanResults = await new AxeBuilder({ page: this.page })
+    .withTags(['wcag2a', 'wcag2aa'])
+    .analyze();
+
+  // Filter for critical and serious violations only
+  const criticalViolations = accessibilityScanResults.violations.filter(
+    v => v.impact === 'critical' || v.impact === 'serious'
+  );
+
+  if (criticalViolations.length > 0) {
+    console.log('Accessibility violations found:');
+    criticalViolations.forEach(v => {
+      console.log(`- ${v.id}: ${v.description} (${v.impact})`);
+      v.nodes.forEach(n => {
+        console.log(`  Target: ${n.target}`);
+      });
+    });
+  }
+
+  expect(criticalViolations.length,
+    `Found ${criticalViolations.length} critical/serious accessibility violations`
+  ).toBe(0);
+});
+
+Then('the modal should have no critical accessibility violations', async function(this: CustomWorld) {
+  // Run axe on the modal content
+  const accessibilityScanResults = await new AxeBuilder({ page: this.page })
+    .include('.modal[style*="block"]')
+    .withTags(['wcag2a', 'wcag2aa'])
+    .analyze();
+
+  const criticalViolations = accessibilityScanResults.violations.filter(
+    v => v.impact === 'critical' || v.impact === 'serious'
+  );
+
+  if (criticalViolations.length > 0) {
+    console.log('Modal accessibility violations found:');
+    criticalViolations.forEach(v => {
+      console.log(`- ${v.id}: ${v.description} (${v.impact})`);
+    });
+  }
+
+  expect(criticalViolations.length,
+    `Found ${criticalViolations.length} critical/serious modal accessibility violations`
+  ).toBe(0);
+});
+
+Then('the modal should have proper ARIA attributes', async function(this: CustomWorld) {
+  const modal = this.page.locator('.modal[style*="block"]');
+
+  // Check role="dialog"
+  const role = await modal.getAttribute('role');
+  expect(role, 'Modal should have role="dialog"').toBe('dialog');
+
+  // Check aria-modal="true"
+  const ariaModal = await modal.getAttribute('aria-modal');
+  expect(ariaModal, 'Modal should have aria-modal="true"').toBe('true');
+
+  // Check aria-labelledby exists
+  const ariaLabelledby = await modal.getAttribute('aria-labelledby');
+  expect(ariaLabelledby, 'Modal should have aria-labelledby').toBeTruthy();
+});
+
+Then('the product list should have no critical accessibility violations', async function(this: CustomWorld) {
+  const accessibilityScanResults = await new AxeBuilder({ page: this.page })
+    .include('.products-grid')
+    .withTags(['wcag2a', 'wcag2aa'])
+    .analyze();
+
+  const criticalViolations = accessibilityScanResults.violations.filter(
+    v => v.impact === 'critical' || v.impact === 'serious'
+  );
+
+  expect(criticalViolations.length,
+    `Found ${criticalViolations.length} critical/serious product list accessibility violations`
+  ).toBe(0);
+});
+
+Then('the checkout form should have proper labels', async function(this: CustomWorld) {
+  // Check that all form inputs have associated labels
+  const inputs = this.page.locator('#checkout-modal input:not([type="hidden"]), #checkout-modal select');
+  const count = await inputs.count();
+
+  for (let i = 0; i < count; i++) {
+    const input = inputs.nth(i);
+    const id = await input.getAttribute('id');
+
+    if (id) {
+      // Check for associated label
+      const label = this.page.locator(`label[for="${id}"]`);
+      const labelExists = await label.count() > 0;
+      expect(labelExists, `Input #${id} should have an associated label`).toBe(true);
+    }
+  }
+});
+
+Then('the skip link should be visible', async function(this: CustomWorld) {
+  const skipLink = this.page.locator('.skip-link');
+
+  // The skip link should be visible when focused
+  await expect(skipLink).toBeFocused();
+
+  // Check that it's visually visible (top should be 0 when focused)
+  const boundingBox = await skipLink.boundingBox();
+  expect(boundingBox, 'Skip link should be visible').toBeTruthy();
+  expect(boundingBox!.y, 'Skip link should be at top of page').toBeGreaterThanOrEqual(0);
+});
+
+Then('the skip link should navigate to main content', async function(this: CustomWorld) {
+  const skipLink = this.page.locator('.skip-link');
+  await skipLink.click();
+  await this.page.waitForTimeout(200);
+
+  // Check that focus moved to main content area or the URL hash changed
+  const url = this.page.url();
+  expect(url, 'URL should contain #main-content').toContain('#main-content');
+});


### PR DESCRIPTION
## Summary
- axe-coreを使用したアクセシビリティテストを追加

## Changes
- `@axe-core/playwright` 依存関係を追加
- `accessibility.feature` (5シナリオ) を作成
- `accessibility.steps.ts` ステップ定義を作成
- `npm run test:a11y` スクリプトを追加

## Test Scenarios
1. ホームページのa11yチェック
2. ログインモーダルのa11yチェック
3. 商品カタログのa11yチェック
4. チェックアウトモーダルのa11yチェック
5. スキップリンクの機能チェック

## How to Run
```bash
cd e2e
npm run test:a11y
```

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)