### PR TITLE
Fix E2E accessibility test failures

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,14 +197,14 @@
                 <h2 data-i18n="product_catalog">商品カタログ</h2>
                 <div class="search-controls">
                     <input type="text" id="search-input" placeholder="商品を検索..." class="search-input" data-i18n-placeholder="search_placeholder">
-                    <select id="category-filter" class="filter-select">
+                    <select id="category-filter" class="filter-select" aria-label="カテゴリフィルター">
                         <option value="" data-i18n="all_categories">すべてのカテゴリ</option>
                         <option value="electronics" data-i18n="electronics">電子機器</option>
                         <option value="clothing" data-i18n="clothing">衣類</option>
                         <option value="books" data-i18n="books">書籍</option>
                         <option value="home" data-i18n="home">ホーム</option>
                     </select>
-                    <select id="sort-select" class="filter-select">
+                    <select id="sort-select" class="filter-select" aria-label="並び替え">
                         <option value="name" data-i18n="sort_name">名前順</option>
                         <option value="price-low" data-i18n="sort_price_low">価格（安い順）</option>
                         <option value="price-high" data-i18n="sort_price_high">価格（高い順）</option>

--- a/user-profile.js
+++ b/user-profile.js
@@ -17,36 +17,52 @@ class UserProfileManager {
 
     initializeEventListeners() {
         // Language switcher
-        document.getElementById('lang-en').addEventListener('click', () => {
-            this.switchLanguage('en');
-        });
-
-        document.getElementById('lang-ja').addEventListener('click', () => {
-            this.switchLanguage('ja');
-        });
+        const langEn = document.getElementById('lang-en');
+        const langJa = document.getElementById('lang-ja');
+        if (langEn) {
+            langEn.addEventListener('click', () => {
+                this.switchLanguage('en');
+            });
+        }
+        if (langJa) {
+            langJa.addEventListener('click', () => {
+                this.switchLanguage('ja');
+            });
+        }
 
         // Logout
-        document.getElementById('logout-btn').addEventListener('click', () => {
-            this.appState.logout();
-            window.location.href = 'index.html';
-        });
+        const logoutBtn = document.getElementById('logout-btn');
+        if (logoutBtn) {
+            logoutBtn.addEventListener('click', () => {
+                this.appState.logout();
+                window.location.href = 'index.html';
+            });
+        }
 
         // Profile form
-        document.getElementById('profile-form').addEventListener('submit', (e) => {
-            this.handleProfileSubmit(e);
-        });
+        const profileForm = document.getElementById('profile-form');
+        if (profileForm) {
+            profileForm.addEventListener('submit', (e) => {
+                this.handleProfileSubmit(e);
+            });
+        }
 
         // Todo
-        document.getElementById('add-todo-btn').addEventListener('click', () => {
-            this.addTodo();
-        });
-
-        document.getElementById('todo-input').addEventListener('keypress', (e) => {
-            if (e.key === 'Enter') {
-                e.preventDefault();
+        const addTodoBtn = document.getElementById('add-todo-btn');
+        const todoInput = document.getElementById('todo-input');
+        if (addTodoBtn) {
+            addTodoBtn.addEventListener('click', () => {
                 this.addTodo();
-            }
-        });
+            });
+        }
+        if (todoInput) {
+            todoInput.addEventListener('keypress', (e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    this.addTodo();
+                }
+            });
+        }
     }
 
     updateUI() {


### PR DESCRIPTION
## Summary
- Add `aria-label` to `#category-filter` and `#sort-select` select elements
- Add null checks to user-profile.js event listeners

## Changes

### index.html
```html
<select id="category-filter" aria-label="カテゴリフィルター">
<select id="sort-select" aria-label="並び替え">
```

### user-profile.js
- Add null checks before adding event listeners to prevent errors on pages without these elements

## Root Cause
The E2E accessibility tests (axe-core) were failing because:
1. Select elements without `aria-label` are flagged as critical violations
2. user-profile.js was throwing errors when elements weren't found

Fixes #55

## Test plan
- [x] Unit tests pass (232 total, 27 skipped)
- [ ] E2E accessibility tests pass (verify in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)