### PR TITLE
Modernize UI with Bento Grid style

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -8,13 +8,14 @@
 /* CSS変数 - Arrangilityコーポレートカラー */
 :root {
     --color-primary: #00a5bf;
-    --color-primary-dark: #008c9e;
+    --color-primary-dark: #007a8c;
+    --color-primary-text: #007a8c; /* WCAG AA対応: 白背景上で4.5:1以上 */
     --color-primary-light: #00c8e0;
     --color-background: #f5f5f7;
     --color-card: #ffffff;
     --color-text: #1d1d1f;
-    --color-text-secondary: #86868b;
-    --color-border: #e8e8ed;
+    --color-text-secondary: #6e6e73; /* WCAG AA対応: 4.5:1以上のコントラスト */
+    --color-border: #d2d2d7;
     --radius-card: 24px;
     --radius-button: 12px;
     --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.06);
@@ -143,9 +144,9 @@ body {
 }
 
 .lang-btn {
-    background: var(--color-background);
+    background: var(--color-card);
     border: 1px solid var(--color-border);
-    color: var(--color-text-secondary);
+    color: var(--color-text);
     padding: 0.4rem 0.75rem;
     border-radius: 8px;
     cursor: pointer;
@@ -155,15 +156,14 @@ body {
 }
 
 .lang-btn:hover {
-    background: var(--color-card);
     border-color: var(--color-primary);
-    color: var(--color-primary);
+    color: var(--color-primary-text);
 }
 
 .lang-btn.active {
-    background: var(--color-primary);
+    background: var(--color-primary-dark);
     color: white;
-    border-color: var(--color-primary);
+    border-color: var(--color-primary-dark);
 }
 
 /* ボタン */
@@ -178,12 +178,12 @@ body {
 }
 
 .btn-primary {
-    background: var(--color-primary);
+    background: var(--color-primary-dark);
     color: white;
 }
 
 .btn-primary:hover {
-    background: var(--color-primary-dark);
+    background: #006575;
     transform: translateY(-1px);
 }
 
@@ -403,7 +403,7 @@ body {
 }
 
 .product-price {
-    color: var(--color-primary);
+    color: var(--color-primary-text);
     font-size: 1.3rem;
     font-weight: 700;
     margin-bottom: 0.5rem;
@@ -499,7 +499,7 @@ body {
     font-family: 'Poppins', sans-serif;
     font-weight: 700;
     font-size: 1.3rem;
-    color: var(--color-primary);
+    color: var(--color-primary-text);
     margin-bottom: 1rem;
     text-align: right;
 }
@@ -730,7 +730,7 @@ body {
 }
 
 .step.active .step-number {
-    background: var(--color-primary);
+    background: var(--color-primary-dark);
     color: white;
 }
 
@@ -779,7 +779,7 @@ body {
 
 .payment-label i {
     font-size: 1.5rem;
-    color: var(--color-primary);
+    color: var(--color-primary-text);
 }
 
 .payment-option input[type="radio"]:checked + .payment-label {


### PR DESCRIPTION
## Summary
- UIをApple風の「Bento Grid」スタイルにモダン化
- Arrangilityコーポレートカラー (#00a5bf) を中心に据えたデザイン

## Changes
- CSS変数を追加してカラースキームを一元管理
- 背景をグラデーションからクリーンなライトグレー (#f5f5f7) に変更
- 商品グリッドをBento Grid レイアウト（最初の商品を2x2で大きく表示）に
- カードを純白デザインと微細なシャドウに更新
- ヘッダー・フッターをシンプルに
- ボタン、入力フィールド、フォーム要素を更新
- Bento Grid用のレスポンシブ対応を追加
- アクセシビリティ機能を維持（フォーカススタイル、prefers-reduced-motion）

## Before/After
| 項目 | Before | After |
|------|--------|-------|
| 背景 | シアングラデーション | ライトグレー (#f5f5f7) |
| カード | グラスモーフィズム | 純白 + 微細シャドウ |
| グリッド | 均等サイズ | Bento Grid (2x2 + 1x1) |
| 角丸 | 20px | 24px |

Fixes #57

## Test plan
- [x] すべてのJestテストが成功
- [ ] 目視でUIの確認
- [ ] レスポンシブ表示の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)