### PR TITLE
Fix CI workflow port mismatch (8000 -> 8001)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -111,11 +111,11 @@ jobs:
       run: |
         npm run serve &
         sleep 5
-        curl -f http://localhost:8000 || (echo "Application failed to start" && exit 1)
+        curl -f http://localhost:8001 || (echo "Application failed to start" && exit 1)
 
     - name: Wait for application to be ready
       run: |
-        timeout 30 bash -c 'until curl -f http://localhost:8000; do sleep 1; done'
+        timeout 30 bash -c 'until curl -f http://localhost:8001; do sleep 1; done'
 
     - name: Run E2E tests
       id: e2e_tests
@@ -139,7 +139,7 @@ jobs:
       env:
         BROWSER: ${{ matrix.browser }}
         HEADLESS: 'true'
-        APP_URL: 'http://localhost:8000'
+        APP_URL: 'http://localhost:8001'
         CI: 'true'
         ALLURE_RESULTS_DIR: './allure-results'
 
@@ -212,7 +212,7 @@ jobs:
       run: |
         npm run serve &
         sleep 5
-        curl -f http://localhost:8000 || (echo "Application failed to start" && exit 1)
+        curl -f http://localhost:8001 || (echo "Application failed to start" && exit 1)
 
     - name: Run parallel E2E tests
       run: |
@@ -220,7 +220,7 @@ jobs:
         npm run test
       env:
         HEADLESS: 'true'
-        APP_URL: 'http://localhost:8000'
+        APP_URL: 'http://localhost:8001'
         CI: 'true'
 
     - name: Upload parallel test results


### PR DESCRIPTION
## Summary
- Update all port references from 8000 to 8001 in e2e-tests.yml
- Fixes CI E2E test failures caused by port mismatch

## Changes
- Line 114, 118: curl health check updated to port 8001
- Line 142: APP_URL environment variable updated
- Line 215, 223: Parallel tests section updated

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)