### PR TITLE
Enable user profile save to backend API

### DIFF
--- a/user-profile.html
+++ b/user-profile.html
@@ -311,6 +311,7 @@
     </footer>
 
     <script src="app.js"></script>
+    <script src="api-client.js"></script>
     <script src="user-profile.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add api-client.js script to user-profile.html for API access
- Make profile load/save operations async to communicate with backend
- When authenticated with JWT, profile data is saved to/loaded from the server
- Falls back to localStorage for demo mode (when not authenticated)

## Changes
- `user-profile.html`: Added `api-client.js` script include
- `user-profile.js`: 
  - `loadProfileData()` → async, loads from API first if authenticated
  - `handleProfileSubmit()` → async, saves to API first if authenticated
  - `updateUI()` → async, awaits `loadProfileData()`

Fixes #71

## Test plan
- [ ] Login with authenticated user and verify profile loads from server
- [ ] Save profile and verify it persists on server (check via API)
- [ ] Logout and verify demo mode still works with localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)