### PR TITLE
パスワード要件の強化

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const i18n = {
         logout: 'ログアウト',
         username: 'ユーザー名:',
         password: 'パスワード:',
-        demo_info: 'デモ用: ユーザー名「demo」、パスワード「password」でログインできます',
+        demo_info: 'デモ用: ユーザー名「demo」、パスワード「Demo@2025!」でログインできます',
         product_catalog: '商品カタログ',
         search_placeholder: '商品を検索...',
         all_categories: 'すべてのカテゴリ',
@@ -95,7 +95,8 @@ const i18n = {
         username_taken: 'このユーザー名は既に使用されています',
         email_taken: 'このメールアドレスは既に登録されています',
         password_mismatch: 'パスワードが一致しません',
-        password_too_short: 'パスワードは6文字以上必要です',
+        password_too_short: 'パスワードは10文字以上必要です',
+        password_complexity: 'パスワードには英字、数字、記号を含める必要があります',
         username_too_short: 'ユーザー名は3文字以上必要です',
         demo_mode_login: 'デモモードでログインしました（バックエンド未接続）',
         backend_required: 'このユーザーでログインするにはバックエンドサーバーが必要です',
@@ -167,7 +168,7 @@ const i18n = {
         logout: 'Logout',
         username: 'Username:',
         password: 'Password:',
-        demo_info: 'Demo: Use username "demo" and password "password" to login',
+        demo_info: 'Demo: Use username "demo" and password "Demo@2025!" to login',
         product_catalog: 'Product Catalog',
         search_placeholder: 'Search products...',
         all_categories: 'All Categories',
@@ -256,7 +257,8 @@ const i18n = {
         username_taken: 'Username is already taken',
         email_taken: 'Email is already registered',
         password_mismatch: 'Passwords do not match',
-        password_too_short: 'Password must be at least 6 characters',
+        password_too_short: 'Password must be at least 10 characters',
+        password_complexity: 'Password must contain letters, numbers, and symbols',
         username_too_short: 'Username must be at least 3 characters',
         demo_mode_login: 'Logged in with demo mode (backend not connected)',
         backend_required: 'Backend server is required to login with this user',
@@ -1022,8 +1024,17 @@ class UIManager {
             return;
         }
 
-        if (password.length < 6) {
+        if (password.length < 10) {
             this.showRegisterError(this.t('password_too_short'));
+            return;
+        }
+
+        // Check password complexity (letters, numbers, symbols)
+        const hasLetter = /[a-zA-Z]/.test(password);
+        const hasNumber = /[0-9]/.test(password);
+        const hasSymbol = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password);
+        if (!hasLetter || !hasNumber || !hasSymbol) {
+            this.showRegisterError(this.t('password_complexity'));
             return;
         }
 

--- a/index.html
+++ b/index.html
@@ -80,11 +80,11 @@
                         </div>
                         <div class="form-group">
                             <label for="register-password" data-i18n="password">パスワード:</label>
-                            <input type="password" id="register-password" name="password" required minlength="6">
+                            <input type="password" id="register-password" name="password" required minlength="10">
                         </div>
                         <div class="form-group">
                             <label for="register-confirm-password" data-i18n="confirm_password">パスワード確認:</label>
-                            <input type="password" id="register-confirm-password" name="confirm-password" required minlength="6">
+                            <input type="password" id="register-confirm-password" name="confirm-password" required minlength="10">
                         </div>
                         <div id="register-error" class="error-message" style="display: none;"></div>
                         <button type="submit" class="btn btn-primary" data-i18n="register">新規登録</button>

--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -15,7 +15,7 @@ async function seed() {
   console.log('Seeding database...');
 
   // Create demo user with hashed password
-  const demoPassword = 'password';
+  const demoPassword = 'Demo@2025!';
   const passwordHash = await bcrypt.hash(demoPassword, config.bcrypt.saltRounds);
 
   const demoUser = {
@@ -61,7 +61,7 @@ async function seed() {
   await fs.writeFile(usersFile, JSON.stringify(users, null, 2), 'utf8');
   console.log('Demo user created/updated successfully!');
   console.log('  Username: demo');
-  console.log('  Password: password');
+  console.log('  Password: Demo@2025!');
 
   // Ensure other data files exist
   const dataFiles = ['carts.json', 'orders.json', 'todos.json'];

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -21,8 +21,11 @@ class AuthService {
     if (!email || !this.isValidEmail(email)) {
       throw new AppError('VALIDATION_ERROR', 'Invalid email format');
     }
-    if (!password || password.length < 6) {
-      throw new AppError('VALIDATION_ERROR', 'Password must be at least 6 characters');
+    if (!password || password.length < 10) {
+      throw new AppError('VALIDATION_ERROR', 'Password must be at least 10 characters');
+    }
+    if (!this.isValidPassword(password)) {
+      throw new AppError('VALIDATION_ERROR', 'Password must contain letters, numbers, and symbols');
     }
 
     // Check if username exists
@@ -104,6 +107,18 @@ class AuthService {
   isValidEmail(email) {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     return emailRegex.test(email);
+  }
+
+  /**
+   * Validate password complexity
+   * @param {string} password - Password to validate
+   * @returns {boolean} True if valid (contains letters, numbers, and symbols)
+   */
+  isValidPassword(password) {
+    const hasLetter = /[a-zA-Z]/.test(password);
+    const hasNumber = /[0-9]/.test(password);
+    const hasSymbol = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password);
+    return hasLetter && hasNumber && hasSymbol;
   }
 
   /**

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -38,11 +38,23 @@ describe('Authentication API', () => {
       expect(res.body.error.code).toBe('VALIDATION_ERROR');
     });
 
-    it('should reject registration with short password (< 6 chars)', async () => {
+    it('should reject registration with short password (< 10 chars)', async () => {
       const res = await registerUser({
         username: 'testuser',
         email: 'test@example.com',
-        password: '12345'
+        password: 'Short@1'
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('should reject registration with password lacking complexity', async () => {
+      const res = await registerUser({
+        username: 'testuser',
+        email: 'test@example.com',
+        password: 'simplepassword'
       });
 
       expect(res.status).toBe(400);

--- a/server/tests/helpers.js
+++ b/server/tests/helpers.js
@@ -1,17 +1,17 @@
 const request = require('supertest');
 const app = require('../index');
 
-// Test user credentials
+// Test user credentials (must meet password requirements: 10+ chars, letters, numbers, symbols)
 const testUser = {
   username: 'testuser',
   email: 'test@example.com',
-  password: 'testpass123'
+  password: 'Test@pass123'
 };
 
 const testUser2 = {
   username: 'testuser2',
   email: 'test2@example.com',
-  password: 'testpass456'
+  password: 'Test@pass456'
 };
 
 // Register a test user and return the response


### PR DESCRIPTION
## Summary
- パスワードの最低文字数を6文字から10文字に変更
- 英字、数字、記号を含む複雑さの要件を追加
- demoユーザーのパスワードを `Demo@2025!` に更新

## 変更内容
- `server/services/authService.js`: サーバー側バリデーション追加
- `app.js`: クライアント側バリデーション追加、i18nメッセージ更新
- `index.html`: フォームのminlength属性を更新
- `server/scripts/seed.js`: demoパスワード更新
- `server/tests/`: テスト更新

## 新しいパスワード要件
- 10文字以上
- 英字を含む
- 数字を含む
- 記号を含む (!@#$%^&*()_+-=[]{}|;':",./<>?)

## Demo認証情報
- ユーザー名: `demo`
- パスワード: `Demo@2025!`

Fixes #75

## Test plan
- [x] サーバーテスト: 55件すべて合格
- [ ] 新規登録時に10文字未満のパスワードが拒否されることを確認
- [ ] 複雑さ要件を満たさないパスワードが拒否されることを確認
- [ ] demoユーザーが新しいパスワードでログインできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)