### PR TITLE
fix: Allure Report Action Docker ビルド失敗を修正

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -371,7 +371,7 @@ jobs:
         path: gh-pages
 
     - name: Build Allure Report
-      uses: simple-elf/allure-report-action@v1.13
+      uses: simple-elf/allure-report-action@master
       if: always()
       with:
         allure_results: allure-results


### PR DESCRIPTION
## Summary
- `simple-elf/allure-report-action` を `@v1.13` から `@master` に更新
- Docker ビルド時の 403 Forbidden エラーを解消

## 問題

GitHub Actions の「Generate Allure Report」ジョブで以下のエラーが発生:

```
ERROR 403: Forbidden
wget --no-verbose -O /tmp/allure-$RELEASE.tgz $ALLURE_REPO/$RELEASE/allure-commandline-$RELEASE.tgz
Docker build failed with exit code 1
```

## 根本原因

v1.13 の Docker イメージビルドで Maven Central からの Allure commandline ダウンロードが 403 Forbidden エラーで失敗。

## 解決策

v1.13 リリース後に Docker イメージの更新コミットがあるため、`@master` を使用。

## Test plan
- [ ] CI の「Generate Allure Report」ジョブが成功することを確認
- [ ] Allure Report が正常に生成されることを確認

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)